### PR TITLE
ARM7/9: Fixed gcc6 build error

### DIFF
--- a/src/target/arm7_9_common.c
+++ b/src/target/arm7_9_common.c
@@ -350,11 +350,12 @@ static int arm7_9_unset_breakpoint(struct target *target, struct breakpoint *bre
 			if (retval != ERROR_OK)
 				return retval;
 			current_instr = target_buffer_get_u16(target, (uint8_t *)&current_instr);
-			if (current_instr == arm7_9->thumb_bkpt)
+			if (current_instr == arm7_9->thumb_bkpt) {
 				retval = target_write_memory(target,
 						breakpoint->address, 2, 1, breakpoint->orig_instr);
 				if (retval != ERROR_OK)
 					return retval;
+			}
 
 		}
 


### PR DESCRIPTION
This error is a real bug where a bracket is missing and because
of it an error condition will not be reported properly.

Signed-off-by: Robert Foss <robert.foss@collabora.com>